### PR TITLE
Fix Caller Issues

### DIFF
--- a/src/API/Caller.php
+++ b/src/API/Caller.php
@@ -99,7 +99,7 @@ class Caller {
         } catch (\Exception $e) {
 
             $status = false;
-            $parsedError = !empty((String) $e->getResponse()->getBody(true)) ? json_decode((String) $e->getResponse()->getBody(true), true) : [];
+            $parsedError = (!empty($e->getResponse()) && !empty((String) $e->getResponse()->getBody(true))) ? json_decode((String) $e->getResponse()->getBody(true), true) : [];
             $errorCode = "M100";
             $errorMessage = "Error! Something Unexpected Happened.";
 
@@ -152,7 +152,7 @@ class Caller {
         } catch (\Exception $e) {
 
             $status = false;
-            $parsedError = !empty((String) $e->getResponse()->getBody(true)) ? json_decode((String) $e->getResponse()->getBody(true), true) : [];
+            $parsedError = (!empty($e->getResponse()) && !empty((String) $e->getResponse()->getBody(true))) ? json_decode((String) $e->getResponse()->getBody(true), true) : [];
             $errorCode = "M100";
             $errorMessage = "Error! Something Unexpected Happened.";
 
@@ -212,7 +212,7 @@ class Caller {
         } catch (\Exception $e) {
 
             $status = false;
-            $parsedError = !empty((String) $e->getResponse()->getBody(true)) ? json_decode((String) $e->getResponse()->getBody(true), true) : [];
+            $parsedError = (!empty($e->getResponse()) && !empty((String) $e->getResponse()->getBody(true))) ? json_decode((String) $e->getResponse()->getBody(true), true) : [];
             $errorCode = "M100";
             $errorMessage = "Error! Something Unexpected Happened.";
 


### PR DESCRIPTION
Fix issue #14 
The Code Used to Test That Feature
```

class ResponseCallback
{
	public static function addIp($caller, $arguments)
	{
		//~
	}
}

$request = new \Clivern\Monkey\API\Request\PlainRequest();
$request->setMethod(\Clivern\Monkey\API\Request\RequestMethod::$GET)
		->setType(\Clivern\Monkey\API\Request\RequestType::$ASYNCHRONOUS)
		->addParameter("command", "startVirtualMachine")
		->addParameter("id", "4c9c8759-de26-41bb-9a22-fe51b9f0c9af");

$response = new \Clivern\Monkey\API\Response\PlainResponse("\ResponseCallback::addIp", ["foo" => "bar"]);


$caller1 = new \Clivern\Monkey\API\Caller($request, $response, "stop_machine", [
	"apiUrl"   => "http://cloudstack.com:8080/client/api",
	"apiKey"    => "api_key_here",
	"secretKey" => "api_secret_key",
	"ssoEnabled" => false,
	"ssoKey" => ""
]);

$caller1->execute();

var_dump($caller1->getStatus());
var_dump($caller1->response()->getResponse());
var_dump($caller1->response()->getError());
var_dump($caller1->response()->getAsyncJobId());

var_dump($caller1->dump(\Clivern\Monkey\API\DumpType::$JSON));

sleep(10);

$caller2 = new \Clivern\Monkey\API\Caller(new \Clivern\Monkey\API\Request\PlainRequest(), new \Clivern\Monkey\API\Response\PlainResponse());

$caller2->reload($caller1->dump(\Clivern\Monkey\API\DumpType::$JSON) , \Clivern\Monkey\API\DumpType::$JSON);

$caller2->execute();

var_dump($caller2->getStatus());
var_dump($caller2->response()->getResponse());
var_dump($caller2->response()->getError());
var_dump($caller2->response()->getAsyncJobId());

var_dump($caller2->dump(\Clivern\Monkey\API\DumpType::$JSON));
```