### PR TITLE
Add option to ignore invalid SSL when trying to connect to CloudStack server on HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ $config = new Config([
     ]
 ]);
 
+// To use self-signed or invalid SSL for connecting to CloudStack
+
+$config = new Config([
+    "us_dc_clsk_01" => [
+        "api_url"   => "https://clsk_url.com:8443/client/api",
+        "api_key"    => "api_key_here",
+        "secret_key" => "secret_key_here",
+        "verify_ssl" => false
+    ]
+]);
+
 // To Check if CloudStack Server Credentials Exists
 $config->isCloudStackServerExists("us_dc_clsk_01"); // Return Boolean
 

--- a/src/API/Caller.php
+++ b/src/API/Caller.php
@@ -32,6 +32,7 @@ class Caller
         'secret_key' => '',
         'sso_enabled' => false,
         'sso_key' => '',
+        'verify_ssl' => true,
     ];
 
     /**
@@ -52,7 +53,7 @@ class Caller
         $this->request = $request;
         $this->response = $response;
         $this->apiData = array_merge($this->apiData, $apiData);
-        $this->client = new Client();
+        $this->client = new Client(['verify' => $this->apiData['verify_ssl']]);
         $this->request->addParameter('apiKey', (isset($apiData['api_key'])) ? $apiData['api_key'] : '');
         $this->status = CallerStatus::$PENDING;
     }


### PR DESCRIPTION
This pull request adds an option to ignore SSL verification.